### PR TITLE
google-tts-api 0.0.2 is not working now.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,17 +67,17 @@
       }
     },
     "google-tts-api": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-tts-api/-/google-tts-api-0.0.2.tgz",
-      "integrity": "sha512-apIfQtuNISGMHXFnWkJTxUwPDf64hio+K1uVUMLn4Y/C/DHCp6kDpasGocJG3ZRv1fzcsu6OCXw8EUxdyyz0fg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/google-tts-api/-/google-tts-api-0.0.3.tgz",
+      "integrity": "sha512-bOEOAjQalxKrRLottV7dwf7KgCVYuZ8gChir1EABYD0EtquwiHb8gnRLWuNAmA30a+UPBD/x26uW935s9jFaJg==",
       "requires": {
         "isomorphic-fetch": "^2.2.1"
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -135,9 +135,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "castv2-client": "^1.2.0",
-    "google-tts-api": "0.0.2"
+    "google-tts-api": "^0.0.3"
   },
   "devDependencies": {},
   "keywords": [


### PR DESCRIPTION
google-tts-api 0.0.2 is not working now, so I update this package version to 0.0.3 and add prefix `^`.